### PR TITLE
Add `xhost +local:` to make user connect to local X server

### DIFF
--- a/2017/run.sh
+++ b/2017/run.sh
@@ -5,6 +5,7 @@ sudo /etc/init.d/pcscd stop
 
 # Ensure user can connect to X server on localhost
 xhost +localhost
+xhost +local:
 
 # Individual Income Tax
 docker run -ti --rm \


### PR DESCRIPTION
Encounter the error below again.
This time, adding `xhost +local:` fixed the problem

```
No protocol specified
Failed to connect to Mir: Failed to connect to server socket: No such
file or directory
Unable to init server: Could not connect: Connection refused
Error: cannot open display: :0
```

ref: <https://askubuntu.com/questions/871092/>